### PR TITLE
docs: warn from using 127 ips

### DIFF
--- a/cmd/arkgopool/settings/sample.config.devnet.toml
+++ b/cmd/arkgopool/settings/sample.config.devnet.toml
@@ -39,4 +39,4 @@ dbfilename = "payment.db"
 payloadsize = 30 #number of transaction sent to block in one payload
 multibroadcast = 10 #to how many peers at once - we can multibroadcast
 autoconfigPeer = "185.170.115.40:4002" #node ip address and port to start talking with blockchain and configure from it there (autoconfigure). 
-#If you are running on the same server you can set it to 127.0.0.1:4001
+#If you are running on the same server do NOT set 127.0.0.1:4001 but your real ip. The node blocks 127 ip's.

--- a/cmd/arkgopool/settings/sample.config.toml
+++ b/cmd/arkgopool/settings/sample.config.toml
@@ -39,4 +39,4 @@ dbfilename = "payment.db"
 payloadsize = 30 #number of transaction sent to block in one payload
 multibroadcast = 10 #to how many peers at once - we can multibroadcast
 autoconfigPeer = "" #node ip address and port to start talking with blockchain and configure from it there (autoconfigure). 
-#If you are running on the same server you can set it to 127.0.0.1:4001
+#If you are running on the same server do NOT set 127.0.0.1:4001 but your real ip. The node blocks 127 ip's.

--- a/cmd/arkgoserver/cfg/sample.config.toml
+++ b/cmd/arkgoserver/cfg/sample.config.toml
@@ -34,6 +34,7 @@ port = 54000
 address = "0.0.0.0"
 dbfilename = "payment.db"
 autoconfigPeer = "" #node ip address and port to start talking with blockchain and configure from it there (autoconfigure)
+#If you are running on the same server do NOT set 127.0.0.1:4001 but your real ip. The node blocks 127 ip's.
 network = "MAINNET" #if autoconfigpeer is not set, network is used
 
 #FRONTEND settings related to page generation


### PR DESCRIPTION
You can't use 127 ip anymore to reference your node for configuration. The nodes block 127 since the 127 "worm".